### PR TITLE
emails: remove additional code related to vault backup emails

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -56,7 +56,6 @@ func main() {
 			Concurrency: 10,
 			Queues: map[string]int{
 				tasks.QUEUE_NAME:         10,
-				tasks.EMAIL_QUEUE_NAME:   100,
 				"scheduled_plugin_queue": 10, // new queue
 			},
 		},

--- a/config-plugin.yaml
+++ b/config-plugin.yaml
@@ -39,9 +39,6 @@ block_storage:
   force_path_style: true
   disable_ssl: true
 
-email_server:
-  api_key: key-1234567890
-
 datadog:
   host: localhost
   port: 8125

--- a/config-server.yaml
+++ b/config-server.yaml
@@ -22,6 +22,4 @@ block_storage:
 
 relay:
   server: "https://api.vultisig.com/router"
-
-email_server:
-  api_key: "your-mandrill-api-key"
+  

--- a/config-verifier.yaml
+++ b/config-verifier.yaml
@@ -41,9 +41,6 @@ block_storage:
   force_path_style: true
   disable_ssl: true
 
-email_server:
-  api_key: key-1234567890
-
 datadog:
   host: localhost
   port: 8125

--- a/config/config.go
+++ b/config/config.go
@@ -48,10 +48,6 @@ type Config struct {
 		Server string `mapstructure:"server" json:"server"`
 	} `mapstructure:"relay" json:"relay,omitempty"`
 
-	EmailServer struct {
-		ApiKey string `mapstructure:"api_key" json:"api_key"`
-	} `mapstructure:"email_server" json:"email_server"`
-
 	BlockStorage struct {
 		Host      string `mapstructure:"host" json:"host"`
 		Region    string `mapstructure:"region" json:"region"`

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -7,11 +7,9 @@ import (
 )
 
 const QUEUE_NAME = "vultisigner"
-const EMAIL_QUEUE_NAME = "vultisigner:email"
 const (
 	TypeKeyGeneration     = "key:generation"
 	TypeKeySign           = "key:sign"
-	TypeEmailVaultBackup  = "key:email"
 	TypeReshare           = "key:reshare"
 	TypePluginTransaction = "plugin:transaction"
 	TypeKeyGenerationDKLS = "key:generationDKLS"

--- a/internal/types/email_request.go
+++ b/internal/types/email_request.go
@@ -1,9 +1,0 @@
-package types
-
-type EmailRequest struct {
-	Email       string `json:"email"`
-	FileName    string `json:"file_name"`
-	FileContent string `json:"file_content"`
-	VaultName   string `json:"vault_name"`
-	Code        string `json:"code"`
-}

--- a/internal/types/vault_resend.go
+++ b/internal/types/vault_resend.go
@@ -1,7 +1,0 @@
-package types
-
-type VaultResendRequest struct {
-	PublicKeyECDSA string `json:"public_key_ecdsa"`
-	Password       string `json:"password"`
-	Email          string `json:"email"`
-}


### PR DESCRIPTION
Removes some more leftover code from vault backup email flows.

This still leaves a few stragglers in naming and interfaces, such as `SaveVaultAndScheduleEmail` - this will be removed/refactored in a subsequent PR to address removal of migration flows that also touch similar parts of the code.

Fixes #12 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed all email-related configuration options from application settings.
  - Eliminated support for email queue processing and related task types.
  - Deleted internal data structures used for handling email requests and vault resend requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->