### PR TITLE
dca,payroll: move plugin-specific policies into plugin pkgs

### DIFF
--- a/internal/types/policy.go
+++ b/internal/types/policy.go
@@ -26,37 +26,3 @@ type PluginPolicy struct {
 type PublicKey struct {
 	// TODO
 }
-
-type PayrollPolicy struct {
-	ChainID    []string           `json:"chain_id"`
-	TokenID    []string           `json:"token_id"`
-	Recipients []PayrollRecipient `json:"recipients"`
-	Schedule   Schedule           `json:"schedule"`
-}
-
-type DCAPolicy struct {
-	ChainID            string     `json:"chain_id"`
-	SourceTokenID      string     `json:"source_token_id"`
-	DestinationTokenID string     `json:"destination_token_id"`
-	TotalAmount        string     `json:"total_amount"`
-	TotalOrders        string     `json:"total_orders"`
-	Schedule           Schedule   `json:"schedule"`
-	PriceRange         PriceRange `json:"price_range"`
-}
-
-type PayrollRecipient struct {
-	Address string `json:"address"`
-	Amount  string `json:"amount"`
-}
-
-type Schedule struct {
-	Frequency string `json:"frequency"`
-	Interval  string `json:"interval"`
-	StartTime string `json:"start_time"`
-	EndTime   string `json:"end_time,omitempty"`
-}
-
-type PriceRange struct {
-	Min string `json:"min"`
-	Max string `json:"max"`
-}

--- a/plugin/dca/dca.go
+++ b/plugin/dca/dca.go
@@ -100,7 +100,7 @@ func (p *DCAPlugin) SigningComplete(
 	signRequest types.PluginKeysignRequest,
 	policy types.PluginPolicy,
 ) error {
-	var dcaPolicy types.DCAPolicy
+	var dcaPolicy DCAPolicy
 	if err := json.Unmarshal(policy.Policy, &dcaPolicy); err != nil {
 		return fmt.Errorf("fail to unmarshal DCA policy: %w", err)
 	}
@@ -173,7 +173,7 @@ func (p *DCAPlugin) ValidatePluginPolicy(policyDoc types.PluginPolicy) error {
 		return fmt.Errorf("invalid public_key")
 	}
 
-	var dcaPolicy types.DCAPolicy
+	var dcaPolicy DCAPolicy
 	if err := json.Unmarshal(policyDoc.Policy, &dcaPolicy); err != nil {
 		return fmt.Errorf("fail to unmarshal DCA policy: %w", err)
 	}
@@ -308,7 +308,7 @@ func (p *DCAPlugin) ProposeTransactions(policy types.PluginPolicy) ([]types.Plug
 		return txs, fmt.Errorf("fail to validate plugin policy: %w", err)
 	}
 
-	var dcaPolicy types.DCAPolicy
+	var dcaPolicy DCAPolicy
 	if err := json.Unmarshal(policy.Policy, &dcaPolicy); err != nil {
 		return txs, fmt.Errorf("fail to unmarshal dca policy, err: %w", err)
 	}
@@ -391,7 +391,7 @@ func (p *DCAPlugin) ValidateProposedTransactions(policy types.PluginPolicy, txs 
 		return fmt.Errorf("failed to validate plugin policy: %w", err)
 	}
 
-	var dcaPolicy types.DCAPolicy
+	var dcaPolicy DCAPolicy
 	if err := json.Unmarshal(policy.Policy, &dcaPolicy); err != nil {
 		return fmt.Errorf("failed to unmarshal DCA policy: %w", err)
 	}

--- a/plugin/dca/policy.go
+++ b/plugin/dca/policy.go
@@ -1,0 +1,25 @@
+package dca
+
+type DCAPolicy struct {
+	ChainID            string     `json:"chain_id"`
+	SourceTokenID      string     `json:"source_token_id"`
+	DestinationTokenID string     `json:"destination_token_id"`
+	TotalAmount        string     `json:"total_amount"`
+	TotalOrders        string     `json:"total_orders"`
+	Schedule           Schedule   `json:"schedule"`
+	PriceRange         PriceRange `json:"price_range"`
+}
+
+type PriceRange struct {
+	Min string `json:"min"`
+	Max string `json:"max"`
+}
+
+// This is duplicated between DCA and Payroll to avoid a 
+// circular top-level dependency on the types package
+type Schedule struct {
+	Frequency string `json:"frequency"`
+	Interval  string `json:"interval"`
+	StartTime string `json:"start_time"`
+	EndTime   string `json:"end_time,omitempty"`
+}

--- a/plugin/payroll/policy.go
+++ b/plugin/payroll/policy.go
@@ -15,6 +15,27 @@ import (
 	"github.com/vultisig/vultiserver-plugin/internal/types"
 )
 
+type PayrollPolicy struct {
+	ChainID    []string           `json:"chain_id"`
+	TokenID    []string           `json:"token_id"`
+	Recipients []PayrollRecipient `json:"recipients"`
+	Schedule   Schedule           `json:"schedule"`
+}
+
+type PayrollRecipient struct {
+	Address string `json:"address"`
+	Amount  string `json:"amount"`
+}
+
+// This is duplicated between DCA and Payroll to avoid a 
+// circular top-level dependency on the types package
+type Schedule struct {
+	Frequency string `json:"frequency"`
+	Interval  string `json:"interval"`
+	StartTime string `json:"start_time"`
+	EndTime   string `json:"end_time,omitempty"`
+}
+
 func (p *PayrollPlugin) ValidateProposedTransactions(policy types.PluginPolicy, txs []types.PluginKeysignRequest) error {
 	err := p.ValidatePluginPolicy(policy)
 	if err != nil {
@@ -26,7 +47,7 @@ func (p *PayrollPlugin) ValidateProposedTransactions(policy types.PluginPolicy, 
 		return fmt.Errorf("failed to parse ABI: %v", err)
 	}
 
-	var payrollPolicy types.PayrollPolicy
+	var payrollPolicy PayrollPolicy
 	if err := json.Unmarshal(policy.Policy, &payrollPolicy); err != nil {
 		return fmt.Errorf("fail to unmarshal payroll policy, err: %w", err)
 	}
@@ -91,7 +112,7 @@ func (p *PayrollPlugin) ValidatePluginPolicy(policyDoc types.PluginPolicy) error
 		return fmt.Errorf("policy does not match plugin type, expected: %s, got: %s", PLUGIN_TYPE, policyDoc.PluginType)
 	}
 
-	var payrollPolicy types.PayrollPolicy
+	var payrollPolicy PayrollPolicy
 	if err := json.Unmarshal(policyDoc.Policy, &payrollPolicy); err != nil {
 		return fmt.Errorf("fail to unmarshal payroll policy, err: %w", err)
 	}

--- a/plugin/payroll/transaction.go
+++ b/plugin/payroll/transaction.go
@@ -36,7 +36,7 @@ func (p *PayrollPlugin) ProposeTransactions(policy types.PluginPolicy) ([]types.
 		return txs, fmt.Errorf("failed to validate plugin policy: %v", err)
 	}
 
-	var payrollPolicy types.PayrollPolicy
+	var payrollPolicy PayrollPolicy
 	if err := json.Unmarshal(policy.Policy, &payrollPolicy); err != nil {
 		return txs, fmt.Errorf("fail to unmarshal payroll policy, err: %w", err)
 	}
@@ -277,7 +277,7 @@ func (p *PayrollPlugin) convertData(signature tss.KeysignResponse, signRequest t
 	}
 
 	policybytes := policy.Policy
-	payrollPolicy := types.PayrollPolicy{}
+	payrollPolicy := PayrollPolicy{}
 	err = json.Unmarshal(policybytes, &payrollPolicy)
 	if err != nil {
 		p.logger.Errorf("Failed to unmarshal policy: %v", err)

--- a/scripts/dev/create_dca_policy/main.go
+++ b/scripts/dev/create_dca_policy/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/vultisig/vultiserver-plugin/config"
 	"github.com/vultisig/vultiserver-plugin/internal/types"
+	dtypes "github.com/vultisig/vultiserver-plugin/plugin/dca"
 )
 
 var vaultName string
@@ -85,20 +86,20 @@ func main() {
 		Signature:     "0x0000000000000000000000000000000000000000000000000000000000000000",
 	}
 
-	payrollPolicy := types.DCAPolicy{
+	dcaPolicy := dtypes.DCAPolicy{
 		ChainID:            "1",
 		SourceTokenID:      sourceTokenContract,
 		DestinationTokenID: destinationTokenContract,
 		TotalAmount:        swapAmountIn,
 		TotalOrders:        "2",
-		Schedule: types.Schedule{
+		Schedule: dtypes.Schedule{
 			Frequency: frequency,
 			Interval:  "",
 			StartTime: time.Now().UTC().Add(20 * time.Second).Format(time.RFC3339),
 		},
 	}
 
-	policyBytes, err := json.Marshal(payrollPolicy)
+	policyBytes, err := json.Marshal(dcaPolicy)
 	if err != nil {
 		panic(err)
 	}

--- a/scripts/dev/create_payroll_policy/main.go
+++ b/scripts/dev/create_payroll_policy/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/vultisig/vultiserver-plugin/config"
 	"github.com/vultisig/vultiserver-plugin/internal/types"
+	ptypes "github.com/vultisig/vultiserver-plugin/plugin/payroll"
 )
 
 var vaultName string
@@ -114,18 +115,18 @@ func main() {
 		Signature:     "0x0000000000000000000000000000000000000000000000000000000000000000",
 	}
 
-	payrollPolicy := types.PayrollPolicy{
+	payrollPolicy := ptypes.PayrollPolicy{
 		ChainID:    chainIDs, // Todo : move this elsewhere, or the frontend deals with this?
 		TokenID:    tokenContracts,
-		Recipients: []types.PayrollRecipient{},
-		Schedule: types.Schedule{
+		Recipients: []ptypes.PayrollRecipient{},
+		Schedule: ptypes.Schedule{
 			Frequency: frequency,
 			StartTime: time.Now().UTC().Add(20 * time.Second).Format(time.RFC3339),
 		},
 	}
 
 	for i, recipient := range recipientAddresses {
-		payrollPolicy.Recipients = append(payrollPolicy.Recipients, types.PayrollRecipient{
+		payrollPolicy.Recipients = append(payrollPolicy.Recipients, ptypes.PayrollRecipient{
 			Address: recipient,
 			Amount:  recipientAmounts[i],
 		})


### PR DESCRIPTION
Plugin-specific policy data should not enter the top-level types package.

This PR moves DCA and Payroll policy types into their respective plugin packages.

It is purely a code restructure and does not have a functional change.

Addresses #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Moved payroll and dollar-cost averaging (DCA) policy definitions into their respective plugins for better modularity.
- **Chores**
  - Removed obsolete internal policy types to simplify the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->