### PR TITLE
plugin: use interface from verifier

### DIFF
--- a/api/plugin.go
+++ b/api/plugin.go
@@ -16,7 +16,7 @@ import (
 	"github.com/vultisig/vultiserver-plugin/internal/sigutil"
 	"github.com/vultisig/vultiserver-plugin/internal/tasks"
 	"github.com/vultisig/vultiserver-plugin/internal/types"
-	"github.com/vultisig/vultiserver-plugin/plugin"
+	"github.com/vultisig/verifier/plugin"
 	"github.com/vultisig/vultiserver-plugin/plugin/dca"
 	"github.com/vultisig/vultiserver-plugin/plugin/payroll"
 	vtypes "github.com/vultisig/verifier/types"
@@ -28,7 +28,7 @@ import (
 func (s *Server) SignPluginMessages(c echo.Context) error {
 	s.logger.Debug("PLUGIN SERVER: SIGN MESSAGES")
 
-	var req types.PluginKeysignRequest
+	var req vtypes.PluginKeysignRequest
 	if err := c.Bind(&req); err != nil {
 		return fmt.Errorf("fail to parse request, err: %w", err)
 	}
@@ -56,7 +56,7 @@ func (s *Server) SignPluginMessages(c echo.Context) error {
 		return fmt.Errorf("failed to initialize plugin: %w", err)
 	}
 
-	if err := plg.ValidateProposedTransactions(policy, []types.PluginKeysignRequest{req}); err != nil {
+	if err := plg.ValidateProposedTransactions(policy, []vtypes.PluginKeysignRequest{req}); err != nil {
 		return fmt.Errorf("failed to validate transaction proposal: %w", err)
 	}
 

--- a/api/server.go
+++ b/api/server.go
@@ -19,7 +19,7 @@ import (
 	"github.com/vultisig/vultiserver-plugin/internal/tasks"
 	"github.com/vultisig/vultiserver-plugin/internal/types"
 	vv "github.com/vultisig/vultiserver-plugin/internal/vultisig_validator"
-	"github.com/vultisig/vultiserver-plugin/plugin"
+	"github.com/vultisig/verifier/plugin"
 	"github.com/vultisig/vultiserver-plugin/plugin/dca"
 	"github.com/vultisig/vultiserver-plugin/plugin/payroll"
 	"github.com/vultisig/vultiserver-plugin/service"
@@ -163,20 +163,7 @@ func (s *Server) StartServer() error {
 	grp.GET("/sign/response/:taskId", s.GetKeysignResult) // Get keysign result
 
 	pluginGroup := e.Group("/plugin")
-
-	// Only enable plugin signing routes if the server is running in plugin mode
-	if s.mode == "plugin" {
-		configGroup := pluginGroup.Group("/configure")
-
-		configGroup.Use(middleware.StaticWithConfig(middleware.StaticConfig{
-			Root:       "frontend",
-			Index:      "index.html",
-			Browse:     false,
-			HTML5:      true,
-			Filesystem: http.FS(s.plugin.FrontendSchema()),
-		}))
-	}
-
+	
 	// policy mode is always available since it is used by both verifier server and plugin server
 	pluginGroup.POST("/policy", s.CreatePluginPolicy)
 	pluginGroup.PUT("/policy", s.UpdatePluginPolicyById)

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/vultisig/commondata v0.0.0-20250430024109-a2492623ef05
 	github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
-	github.com/vultisig/verifier v0.0.0-20250504234329-7a462fa6fc27
+	github.com/vultisig/verifier v0.0.0-20250505001859-2eb387bd493b
 	github.com/vultisig/vultiserver v0.0.0-20250421043311-443d711d503d
 	google.golang.org/protobuf v1.36.6
 )

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f h1:124Xlloih1
 github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f/go.mod h1:UfGCxUQW08kiwxyNBiHwXe+ePPuBmHVVS+BS51aU/Jg=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4nQ/NEVIb3OPP9SUx7/u9ZfsUIcd5fIN/e4DVU=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
-github.com/vultisig/verifier v0.0.0-20250504234329-7a462fa6fc27 h1:n7IfRh7iW6HIkSKJnN3YdFp7cyEHBSVwU1ISu4Rg3BM=
-github.com/vultisig/verifier v0.0.0-20250504234329-7a462fa6fc27/go.mod h1:eg5tXKxJSG2b9wfEa1rH4JCIsAAyV1GLLSKYc1Q6chU=
+github.com/vultisig/verifier v0.0.0-20250505001859-2eb387bd493b h1:sf+99rA/MW2E9e8CYwXt75ul0dpwl1mCisQ9egSoZts=
+github.com/vultisig/verifier v0.0.0-20250505001859-2eb387bd493b/go.mod h1:eg5tXKxJSG2b9wfEa1rH4JCIsAAyV1GLLSKYc1Q6chU=
 github.com/vultisig/vultiserver v0.0.0-20250421043311-443d711d503d h1:cXQm8SK1TJe/YIdCtQNrItVctABI3xe/L5Te0PmohTY=
 github.com/vultisig/vultiserver v0.0.0-20250421043311-443d711d503d/go.mod h1:HwP2IgW6Mcu/gX8paFuKvfibrGE9UmPgkOFTub6dskM=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=

--- a/plugin/dca/dca.go
+++ b/plugin/dca/dca.go
@@ -2,7 +2,6 @@ package dca
 
 import (
 	"context"
-	"embed"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -98,7 +97,7 @@ func NewDCAPlugin(db storage.DatabaseStorage, logger *logrus.Logger, rawConfig m
 func (p *DCAPlugin) SigningComplete(
 	ctx context.Context,
 	signature tss.KeysignResponse,
-	signRequest types.PluginKeysignRequest,
+	signRequest vtypes.PluginKeysignRequest,
 	policy vtypes.PluginPolicy,
 ) error {
 	var dcaPolicy DCAPolicy
@@ -298,10 +297,10 @@ func validateInterval(intervalStr string, frequency string) error {
 	return nil
 }
 
-func (p *DCAPlugin) ProposeTransactions(policy vtypes.PluginPolicy) ([]types.PluginKeysignRequest, error) {
+func (p *DCAPlugin) ProposeTransactions(policy vtypes.PluginPolicy) ([]vtypes.PluginKeysignRequest, error) {
 	p.logger.Info("DCA: PROPOSE TRANSACTIONS")
 
-	var txs []types.PluginKeysignRequest
+	var txs []vtypes.PluginKeysignRequest
 
 	// validate policy
 	err := p.ValidatePluginPolicy(policy)
@@ -359,8 +358,8 @@ func (p *DCAPlugin) ProposeTransactions(policy vtypes.PluginPolicy) ([]types.Plu
 	}
 
 	for _, data := range rawTxsData {
-		signRequest := types.PluginKeysignRequest{
-			KeysignRequest: types.KeysignRequest{
+		signRequest := vtypes.PluginKeysignRequest{
+			KeysignRequest: vtypes.KeysignRequest{
 				PublicKey:        policy.PublicKey,
 				Messages:         []string{hex.EncodeToString(data.TxHash)},
 				SessionID:        uuid.New().String(),
@@ -381,7 +380,7 @@ func (p *DCAPlugin) ProposeTransactions(policy vtypes.PluginPolicy) ([]types.Plu
 	return txs, nil
 }
 
-func (p *DCAPlugin) ValidateProposedTransactions(policy vtypes.PluginPolicy, txs []types.PluginKeysignRequest) error {
+func (p *DCAPlugin) ValidateProposedTransactions(policy vtypes.PluginPolicy, txs []vtypes.PluginKeysignRequest) error {
 	p.logger.Info("DCA: VALIDATE TRANSACTION PROPOSAL")
 
 	if len(txs) == 0 {
@@ -444,7 +443,7 @@ func (p *DCAPlugin) ValidateProposedTransactions(policy vtypes.PluginPolicy, txs
 	return nil
 }
 
-func (p *DCAPlugin) validateTransaction(keysignRequest types.PluginKeysignRequest, completedSwaps int64, policyTotalAmount, policyTotalOrders, policyChainID *big.Int, sourceAddrPolicy, destAddrPolicy, signerAddress *gcommon.Address) error {
+func (p *DCAPlugin) validateTransaction(keysignRequest vtypes.PluginKeysignRequest, completedSwaps int64, policyTotalAmount, policyTotalOrders, policyChainID *big.Int, sourceAddrPolicy, destAddrPolicy, signerAddress *gcommon.Address) error {
 	// Parse the transaction
 	var tx *gtypes.Transaction
 	txBytes, err := hex.DecodeString(keysignRequest.Transaction)
@@ -680,10 +679,6 @@ func (p *DCAPlugin) getApproveABI() (abi.ABI, error) {
 	]`
 
 	return abi.JSON(strings.NewReader(approveABI))
-}
-
-func (p *DCAPlugin) FrontendSchema() embed.FS {
-	return embed.FS{}
 }
 
 type RawTxData struct {

--- a/plugin/payroll/frontend/index.html
+++ b/plugin/payroll/frontend/index.html
@@ -1,9 +1,0 @@
-<html>
-  <head>
-    <title>My First Web Page</title>
-  </head>
-  <body>
-    <h1>Welcome to my first web page!</h1>
-    <p>This is a paragraph of text.</p>
-  </body>
-</html>

--- a/plugin/payroll/nonce.go
+++ b/plugin/payroll/nonce.go
@@ -1,4 +1,4 @@
-package plugin
+package payroll
 
 import (
 	"context"

--- a/plugin/payroll/payroll.go
+++ b/plugin/payroll/payroll.go
@@ -1,21 +1,15 @@
 package payroll
 
 import (
-	"embed"
-
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/mitchellh/mapstructure"
 	"github.com/sirupsen/logrus"
-	"github.com/vultisig/vultiserver-plugin/plugin"
 	"github.com/vultisig/vultiserver-plugin/storage"
 )
 
-//go:embed frontend
-var frontend embed.FS
-
 type PayrollPlugin struct {
 	db           storage.DatabaseStorage
-	nonceManager *plugin.NonceManager
+	nonceManager *NonceManager
 	rpcClient    *ethclient.Client
 	logger       logrus.FieldLogger
 }
@@ -38,13 +32,9 @@ func NewPayrollPlugin(db storage.DatabaseStorage, logger logrus.FieldLogger, raw
 	return &PayrollPlugin{
 		db:           db,
 		rpcClient:    rpcClient,
-		nonceManager: plugin.NewNonceManager(rpcClient),
+		nonceManager: NewNonceManager(rpcClient),
 		logger:       logger,
 	}, nil
-}
-
-func (p *PayrollPlugin) FrontendSchema() embed.FS {
-	return frontend
 }
 
 func (p *PayrollPlugin) GetNextNonce(address string) (uint64, error) {

--- a/plugin/payroll/policy.go
+++ b/plugin/payroll/policy.go
@@ -12,7 +12,6 @@ import (
 	gtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/sirupsen/logrus"
-	"github.com/vultisig/vultiserver-plugin/internal/types"
 	vtypes "github.com/vultisig/verifier/types"
 )
 
@@ -37,7 +36,7 @@ type Schedule struct {
 	EndTime   string `json:"end_time,omitempty"`
 }
 
-func (p *PayrollPlugin) ValidateProposedTransactions(policy vtypes.PluginPolicy, txs []types.PluginKeysignRequest) error {
+func (p *PayrollPlugin) ValidateProposedTransactions(policy vtypes.PluginPolicy, txs []vtypes.PluginKeysignRequest) error {
 	err := p.ValidatePluginPolicy(policy)
 	if err != nil {
 		return fmt.Errorf("failed to validate plugin policy: %v", err)

--- a/plugin/payroll/transaction.go
+++ b/plugin/payroll/transaction.go
@@ -87,7 +87,7 @@ func (p *PayrollPlugin) ProposeTransactions(policy vtypes.PluginPolicy) ([]vtype
 	err = tx.UnmarshalBinary(txBytes)
 	if err != nil {
 		p.logger.Errorf("Failed to unmarshal transaction: %v", err)
-		return []vtypes.PluginKeysignRequest{}, fmt.Errorf("failed to unmarshal transaction: %d:", err)
+		return []vtypes.PluginKeysignRequest{}, fmt.Errorf("failed to unmarshal transaction: %w:", err)
 	}
 	fmt.Printf("Chain ID TEST 2: %s\n", tx.ChainId().String())
 	fmt.Printf("len TEST 2: %d\n", len(txs))

--- a/plugin/payroll/transaction.go
+++ b/plugin/payroll/transaction.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/sirupsen/logrus"
 	"github.com/vultisig/mobile-tss-lib/tss"
-	"github.com/vultisig/vultiserver-plugin/internal/types"
 	vtypes "github.com/vultisig/verifier/types"
 )
 
@@ -30,8 +29,8 @@ const (
 	hexEncryptionKey = "hexencryptionkey"
 )
 
-func (p *PayrollPlugin) ProposeTransactions(policy vtypes.PluginPolicy) ([]types.PluginKeysignRequest, error) {
-	var txs []types.PluginKeysignRequest
+func (p *PayrollPlugin) ProposeTransactions(policy vtypes.PluginPolicy) ([]vtypes.PluginKeysignRequest, error) {
+	var txs []vtypes.PluginKeysignRequest
 	err := p.ValidatePluginPolicy(policy)
 	if err != nil {
 		return txs, fmt.Errorf("failed to validate plugin policy: %v", err)
@@ -54,14 +53,14 @@ func (p *PayrollPlugin) ProposeTransactions(policy vtypes.PluginPolicy) ([]types
 		)
 		fmt.Printf("Chain ID TEST 1: %s\n", payrollPolicy.ChainID[i])
 		if err != nil {
-			return []types.PluginKeysignRequest{}, fmt.Errorf("failed to generate transaction hash: %v", err)
+			return []vtypes.PluginKeysignRequest{}, fmt.Errorf("failed to generate transaction hash: %v", err)
 		}
 
 		chainIDInt, _ := strconv.ParseInt(payrollPolicy.ChainID[i], 10, 64)
 
 		// Create signing request
-		signRequest := types.PluginKeysignRequest{
-			KeysignRequest: types.KeysignRequest{
+		signRequest := vtypes.PluginKeysignRequest{
+			KeysignRequest: vtypes.KeysignRequest{
 				PublicKey:        policy.PublicKey,
 				Messages:         []string{hex.EncodeToString(txHash)},
 				SessionID:        uuid.New().String(),
@@ -81,14 +80,14 @@ func (p *PayrollPlugin) ProposeTransactions(policy vtypes.PluginPolicy) ([]types
 	txBytes, err := hex.DecodeString(signRequest.Transaction)
 	if err != nil {
 		p.logger.Errorf("Failed to decode transaction hex: %v", err)
-		return []types.PluginKeysignRequest{}, fmt.Errorf("failed to decode transaction hex: %w", err)
+		return []vtypes.PluginKeysignRequest{}, fmt.Errorf("failed to decode transaction hex: %w", err)
 	}
 	//unmarshal tx from sign req.transaction
 	tx := &gtypes.Transaction{}
 	err = tx.UnmarshalBinary(txBytes)
 	if err != nil {
 		p.logger.Errorf("Failed to unmarshal transaction: %v", err)
-		return []types.PluginKeysignRequest{}, fmt.Errorf("failed to unmarshal transaction: %d:", err)
+		return []vtypes.PluginKeysignRequest{}, fmt.Errorf("failed to unmarshal transaction: %d:", err)
 	}
 	fmt.Printf("Chain ID TEST 2: %s\n", tx.ChainId().String())
 	fmt.Printf("len TEST 2: %d\n", len(txs))
@@ -207,7 +206,7 @@ func (p *PayrollPlugin) generatePayrollTransaction(amountString, recipientString
 	return txHash, rawTx, nil
 }
 
-func (p *PayrollPlugin) SigningComplete(ctx context.Context, signature tss.KeysignResponse, signRequest types.PluginKeysignRequest, policy vtypes.PluginPolicy) error {
+func (p *PayrollPlugin) SigningComplete(ctx context.Context, signature tss.KeysignResponse, signRequest vtypes.PluginKeysignRequest, policy vtypes.PluginPolicy) error {
 	R, S, V, originalTx, chainID, _, err := p.convertData(signature, signRequest, policy)
 	if err != nil {
 		return fmt.Errorf("failed to convert R and S: %v", err)
@@ -250,7 +249,7 @@ func (p *PayrollPlugin) SigningComplete(ctx context.Context, signature tss.Keysi
 	return p.monitorTransaction(signedTx)
 }
 
-func (p *PayrollPlugin) convertData(signature tss.KeysignResponse, signRequest types.PluginKeysignRequest, policy vtypes.PluginPolicy) (R *big.Int, S *big.Int, V *big.Int, originalTx *gtypes.Transaction, chainID *big.Int, recoveryID int64, err error) {
+func (p *PayrollPlugin) convertData(signature tss.KeysignResponse, signRequest vtypes.PluginKeysignRequest, policy vtypes.PluginPolicy) (R *big.Int, S *big.Int, V *big.Int, originalTx *gtypes.Transaction, chainID *big.Int, recoveryID int64, err error) {
 	// convert R and S from hex strings to big.Int
 	R = new(big.Int)
 	R.SetString(signature.R, 16)

--- a/service/worker.go
+++ b/service/worker.go
@@ -23,13 +23,14 @@ import (
 	"github.com/vultisig/vultiserver-plugin/internal/syncer"
 	"github.com/vultisig/vultiserver-plugin/internal/tasks"
 	"github.com/vultisig/vultiserver-plugin/internal/types"
-	"github.com/vultisig/vultiserver-plugin/plugin"
+	"github.com/vultisig/verifier/plugin"
 	"github.com/vultisig/vultiserver-plugin/plugin/dca"
 	"github.com/vultisig/vultiserver-plugin/plugin/payroll"
 	"github.com/vultisig/vultiserver-plugin/relay"
 	"github.com/vultisig/vultiserver-plugin/storage"
 	"github.com/vultisig/vultiserver-plugin/storage/postgres"
 	"github.com/vultisig/vultiserver/contexthelper"
+	vtypes "github.com/vultisig/verifier/types"
 )
 
 type WorkerService struct {
@@ -417,7 +418,7 @@ func (s *WorkerService) HandlePluginTransaction(ctx context.Context, t *asynq.Ta
 	return nil
 }
 
-func (s *WorkerService) initiateTxSignWithVerifier(ctx context.Context, signRequest types.PluginKeysignRequest, metadata map[string]interface{}, newTx types.TransactionHistory) error {
+func (s *WorkerService) initiateTxSignWithVerifier(ctx context.Context, signRequest vtypes.PluginKeysignRequest, metadata map[string]interface{}, newTx types.TransactionHistory) error {
 	signBytes, err := json.Marshal(signRequest)
 	if err != nil {
 		s.logger.Errorf("Failed to marshal sign request: %v", err)


### PR DESCRIPTION
Resolves #20

This removes the local interface copy and instead pulls it in from verifier repo.

It also drops the frontend stub from the previous implementation, and (temporarily) moves nonce manager into the payroll package.

Nonce manager should be refactored a bit later in the process - we can likely do away with it in favour of a simple counter within the payroll package, or elevate it to be an internal package used by DCA (for approval + swap) and payroll. However, it works for now, so we can circle back to it after the base functional changes are done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated several plugin and service components to use external verifier types for transaction signing requests, improving consistency across the system.
  - Removed embedded frontend files and related methods from plugins, streamlining the codebase.
  - Adjusted internal struct field types and method signatures to align with new type imports.

- **Chores**
  - Upgraded the verifier dependency to a newer version.
  - Cleaned up unused imports and removed obsolete frontend files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->