### PR TITLE
storage: drop plugin_type, add recipe

### DIFF
--- a/api/plugin.go
+++ b/api/plugin.go
@@ -307,13 +307,13 @@ func (s *Server) DeletePluginPolicyById(c echo.Context) error {
 }
 
 func (s *Server) GetPolicySchema(c echo.Context) error {
-	pluginType := c.Request().Header.Get("plugin_type") // this is a unique identifier; this won't be needed once the DCA and Payroll are separate services
-	if pluginType == "" {
-		return c.JSON(http.StatusBadRequest, NewErrorResponse("missing required header: plugin_type"))
+	pluginID := c.Request().Header.Get("plugin_id") // this is a unique identifier; this won't be needed once the DCA and Payroll are separate services
+	if pluginID == "" {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("missing required header: plugin_id"))
 	}
 
 	// TODO: need to deal with both DCA and Payroll plugins
-	keyPath := filepath.Join("plugin", pluginType, "dcaPluginUiSchema.json")
+	keyPath := filepath.Join("plugin", pluginID, "dcaPluginUiSchema.json")
 	jsonData, err := os.ReadFile(keyPath)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to read plugin schema"))

--- a/api/plugin.go
+++ b/api/plugin.go
@@ -171,17 +171,17 @@ func (s *Server) GetAllPluginPolicies(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("missing required header: public_key"))
 	}
 
-	pluginType := c.Request().Header.Get("plugin_type")
-	if pluginType == "" {
-		return c.JSON(http.StatusBadRequest, NewErrorResponse("missing required header: plugin_type"))
+	pluginID := c.Request().Header.Get("plugin_id")
+	if pluginID == "" {
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("missing required header: plugin_id"))
 	}
 
-	policies, err := s.policyService.GetPluginPolicies(c.Request().Context(), publicKey, pluginType)
+	policies, err := s.policyService.GetPluginPolicies(c.Request().Context(), vtypes.PluginID(pluginID), publicKey)
 	if err != nil {
 		s.logger.WithError(err).WithFields(
 			logrus.Fields{
-				"public_key":  publicKey,
-				"plugin_type": pluginType,
+				"public_key": publicKey,
+				"plugin_id":  pluginID,
 			}).Error("failed to get policies")
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to get policies"))
 	}

--- a/api/plugin.go
+++ b/api/plugin.go
@@ -62,7 +62,7 @@ func (s *Server) SignPluginMessages(c echo.Context) error {
 
 	// We re-init plugin as verification server doesn't have plugin defined
 	var plg plugin.Plugin
-	plg, err = s.initializePlugin(policy.PluginType)
+	plg, err = s.initializePlugin(policy.PluginID)
 	if err != nil {
 		return fmt.Errorf("failed to initialize plugin: %w", err)
 	}
@@ -198,10 +198,10 @@ func (s *Server) CreatePluginPolicy(c echo.Context) error {
 	// We re-init plugin as verification server doesn't have plugin defined
 
 	var plg plugin.Plugin
-	plg, err := s.initializePlugin(policy.PluginType)
+	plg, err := s.initializePlugin(policy.PluginID)
 	if err != nil {
 		s.logger.WithError(err).
-			WithField("plugin_type", policy.PluginType).
+			WithField("plugin_id", policy.PluginID).
 			Error("Failed to initialize plugin")
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("failed to initialize plugin"))
 	}
@@ -237,17 +237,17 @@ func (s *Server) UpdatePluginPolicyById(c echo.Context) error {
 
 	// We re-init plugin as verification server doesn't have plugin defined
 	var plg plugin.Plugin
-	plg, err := s.initializePlugin(policy.PluginType)
+	plg, err := s.initializePlugin(policy.PluginID)
 	if err != nil {
 		s.logger.WithError(err).
-			WithField("plugin_type", policy.PluginType).
+			WithField("plugin_id", policy.PluginID).
 			Error("Failed to initialize plugin")
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("failed to initialize plugin"))
 	}
 
 	if err := plg.ValidatePluginPolicy(policy); err != nil {
 		s.logger.WithError(err).
-			WithField("plugin_type", policy.PluginType).
+			WithField("plugin_id", policy.PluginID).
 			WithField("policy_id", policy.ID).
 			Error("Failed to validate plugin policy")
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("failed to validate policy"))
@@ -346,14 +346,14 @@ func (s *Server) GetPluginPolicyTransactionHistory(c echo.Context) error {
 	return c.JSON(http.StatusOK, policyHistory)
 }
 
-func (s *Server) initializePlugin(pluginType string) (plugin.Plugin, error) {
-	switch pluginType {
-	case "payroll":
+func (s *Server) initializePlugin(pluginID vtypes.PluginID) (plugin.Plugin, error) {
+	switch pluginID {
+	case vtypes.PluginVultisigPayroll_0000:
 		return payroll.NewPayrollPlugin(s.db, s.logger, s.cfg.Server.BaseConfigPath)
-	case "dca":
+	case vtypes.PluginVultisigDCA_0000:
 		return dca.NewDCAPlugin(s.db, s.logger, s.cfg.Server.BaseConfigPath)
 	default:
-		return nil, fmt.Errorf("unknown plugin type: %s", pluginType)
+		return nil, fmt.Errorf("unknown plugin type: %s", pluginID)
 	}
 }
 func (s *Server) verifyPolicySignature(policy vtypes.PluginPolicy, update bool) bool {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/vultisig/commondata v0.0.0-20250430024109-a2492623ef05
 	github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74
-	github.com/vultisig/verifier v0.0.0-20250513124642-41d01a15b222
+	github.com/vultisig/verifier v0.0.0-20250518231539-6ca51be2f52b
 	github.com/vultisig/vultiserver v0.0.0-20250421043311-443d711d503d
 	google.golang.org/protobuf v1.36.6
 )
@@ -160,7 +160,6 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/otiai10/primes v0.4.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -733,10 +733,8 @@ github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f h1:124Xlloih1
 github.com/vultisig/go-wrappers v0.0.0-20250403041248-86911e8aa33f/go.mod h1:UfGCxUQW08kiwxyNBiHwXe+ePPuBmHVVS+BS51aU/Jg=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74 h1:goqwk4nQ/NEVIb3OPP9SUx7/u9ZfsUIcd5fIN/e4DVU=
 github.com/vultisig/mobile-tss-lib v0.0.0-20250316003201-2e7e570a4a74/go.mod h1:nOykk4nOy1L3yXtLSlYvVsgizBnCQ3tR2N5uwGPdvaM=
-github.com/vultisig/verifier v0.0.0-20250505093115-fdb5db2c4297 h1:4cfDBa2Y7Yqk50/NoB7xAfvKbdYswYyyu8wJEMx+HH4=
-github.com/vultisig/verifier v0.0.0-20250505093115-fdb5db2c4297/go.mod h1:DcF9+VRekQ1M1oR4Ntni9xqFSTqvVMUy9nwdItg5Rk4=
-github.com/vultisig/verifier v0.0.0-20250513124642-41d01a15b222 h1:nb+OQcBXeFQ7W3ES5d32+UxjXCc5xaSRqwUV0oLQfEI=
-github.com/vultisig/verifier v0.0.0-20250513124642-41d01a15b222/go.mod h1:yLi3+WMVsA3FOKwTZm9QGmXQw14qWH3cDzg4JkB+jqg=
+github.com/vultisig/verifier v0.0.0-20250518231539-6ca51be2f52b h1:BzBf8k2qvNNK6XW8SbsY9jGLgbNHxDxLeW7kXLdu+Zg=
+github.com/vultisig/verifier v0.0.0-20250518231539-6ca51be2f52b/go.mod h1:yLi3+WMVsA3FOKwTZm9QGmXQw14qWH3cDzg4JkB+jqg=
 github.com/vultisig/vultiserver v0.0.0-20250421043311-443d711d503d h1:cXQm8SK1TJe/YIdCtQNrItVctABI3xe/L5Te0PmohTY=
 github.com/vultisig/vultiserver v0.0.0-20250421043311-443d711d503d/go.mod h1:HwP2IgW6Mcu/gX8paFuKvfibrGE9UmPgkOFTub6dskM=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/plugin/dca/dca.go
+++ b/plugin/dca/dca.go
@@ -134,8 +134,8 @@ func (p *DCAPlugin) SigningComplete(
 }
 
 func (p *DCAPlugin) ValidatePluginPolicy(policyDoc vtypes.PluginPolicy) error {
-	if policyDoc.PluginType != pluginType {
-		return fmt.Errorf("policy does not match plugin type, expected: %s, got: %s", pluginType, policyDoc.PluginType)
+	if policyDoc.PluginID != vtypes.PluginVultisigDCA_0000 {
+		return fmt.Errorf("policy does not match plugin type, expected: %s, got: %s", pluginType, policyDoc.PluginID)
 	}
 
 	if policyDoc.PluginVersion != pluginVersion {

--- a/plugin/payroll/policy.go
+++ b/plugin/payroll/policy.go
@@ -108,8 +108,8 @@ func (p *PayrollPlugin) ValidateProposedTransactions(policy vtypes.PluginPolicy,
 }
 
 func (p *PayrollPlugin) ValidatePluginPolicy(policyDoc vtypes.PluginPolicy) error {
-	if policyDoc.PluginType != PLUGIN_TYPE {
-		return fmt.Errorf("policy does not match plugin type, expected: %s, got: %s", PLUGIN_TYPE, policyDoc.PluginType)
+	if policyDoc.PluginID != vtypes.PluginVultisigPayroll_0000 {
+		return fmt.Errorf("policy does not match plugin type, expected: %s, got: %s", vtypes.PluginVultisigPayroll_0000, policyDoc.PluginID)
 	}
 
 	var payrollPolicy PayrollPolicy

--- a/scripts/dev/create_dca_policy/main.go
+++ b/scripts/dev/create_dca_policy/main.go
@@ -79,10 +79,9 @@ func main() {
 	policy := vtypes.PluginPolicy{
 		ID:            policyId,
 		PublicKey:     key,
-		PluginID:      uuid.New(), // update it to DCA plugin ID
+		PluginID:      vtypes.PluginVultisigDCA_0000,
 		PluginVersion: "1.0.0",
 		PolicyVersion: "1.0.0",
-		PluginType:    "dca",
 		Active:        true,
 		Signature:     "0x0000000000000000000000000000000000000000000000000000000000000000",
 	}

--- a/scripts/dev/create_payroll_policy/main.go
+++ b/scripts/dev/create_payroll_policy/main.go
@@ -108,10 +108,9 @@ func main() {
 	policy := vtypes.PluginPolicy{
 		ID:            policyId,
 		PublicKey:     key,
-		PluginID:      uuid.New(), // update it to payroll plugin ID
+		PluginID:      vtypes.PluginVultisigPayroll_0000,
 		PluginVersion: "1.0.0",
 		PolicyVersion: "1.0.0",
-		PluginType:    "payroll",
 		Active:        true,
 		Signature:     "0x0000000000000000000000000000000000000000000000000000000000000000",
 	}

--- a/service/policy.go
+++ b/service/policy.go
@@ -18,7 +18,7 @@ type Policy interface {
 	CreatePolicy(ctx context.Context, policy vtypes.PluginPolicy) (*vtypes.PluginPolicy, error)
 	UpdatePolicy(ctx context.Context, policy vtypes.PluginPolicy) (*vtypes.PluginPolicy, error)
 	DeletePolicy(ctx context.Context, policyID, signature string) error
-	GetPluginPolicies(ctx context.Context, pluginType, publicKey string) ([]vtypes.PluginPolicy, error)
+	GetPluginPolicies(ctx context.Context, pluginID vtypes.PluginID, publicKey string) ([]vtypes.PluginPolicy, error)
 	GetPluginPolicy(ctx context.Context, policyID string) (vtypes.PluginPolicy, error)
 	GetPluginPolicyTransactionHistory(ctx context.Context, policyID string) ([]types.TransactionHistory, error)
 }
@@ -127,8 +127,8 @@ func (s *PolicyService) DeletePolicy(ctx context.Context, policyID, signature st
 	return nil
 }
 
-func (s *PolicyService) GetPluginPolicies(ctx context.Context, pluginType, publicKey string) ([]vtypes.PluginPolicy, error) {
-	policies, err := s.db.GetAllPluginPolicies(ctx, pluginType, publicKey)
+func (s *PolicyService) GetPluginPolicies(ctx context.Context, pluginID vtypes.PluginID, publicKey string) ([]vtypes.PluginPolicy, error) {
+	policies, err := s.db.GetAllPluginPolicies(ctx, publicKey, pluginID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get policies: %w", err)
 	}

--- a/storage/db.go
+++ b/storage/db.go
@@ -18,7 +18,7 @@ type DatabaseStorage interface {
 	FindUserByName(ctx context.Context, username string) (*types.UserWithPassword, error)
 
 	GetPluginPolicy(ctx context.Context, id string) (vtypes.PluginPolicy, error)
-	GetAllPluginPolicies(ctx context.Context, publicKey string, pluginType string) ([]vtypes.PluginPolicy, error)
+	GetAllPluginPolicies(ctx context.Context, publicKey string, pluginID vtypes.PluginID) ([]vtypes.PluginPolicy, error)
 	DeletePluginPolicyTx(ctx context.Context, dbTx pgx.Tx, id string) error
 	InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx, policy vtypes.PluginPolicy) (*vtypes.PluginPolicy, error)
 	UpdatePluginPolicyTx(ctx context.Context, dbTx pgx.Tx, policy vtypes.PluginPolicy) (*vtypes.PluginPolicy, error)

--- a/storage/postgres/migrations/20250518213405_add_recipe_to_policy.sql
+++ b/storage/postgres/migrations/20250518213405_add_recipe_to_policy.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE plugin_policies
+    ADD COLUMN recipe TEXT NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE plugin_policies
+    DROP COLUMN recipe;
+-- +goose StatementEnd

--- a/storage/postgres/policy.go
+++ b/storage/postgres/policy.go
@@ -44,7 +44,7 @@ func (p *PostgresBackend) GetPluginPolicy(ctx context.Context, id string) (vtype
 	return policy, nil
 }
 
-func (p *PostgresBackend) GetAllPluginPolicies(ctx context.Context, publicKey string, pluginType string) ([]vtypes.PluginPolicy, error) {
+func (p *PostgresBackend) GetAllPluginPolicies(ctx context.Context, publicKey string, pluginID vtypes.PluginID) ([]vtypes.PluginPolicy, error) {
 	if p.pool == nil {
 		return []vtypes.PluginPolicy{}, fmt.Errorf("database pool is nil")
 	}
@@ -53,9 +53,9 @@ func (p *PostgresBackend) GetAllPluginPolicies(ctx context.Context, publicKey st
   	SELECT id, public_key,  plugin_id, plugin_version, policy_version, signature, active, policy, recipe
 		FROM plugin_policies
 		WHERE public_key = $1
-		AND plugin_type = $2`
+		AND plugin_id = $2`
 
-	rows, err := p.pool.Query(ctx, query, publicKey, pluginType)
+	rows, err := p.pool.Query(ctx, query, publicKey, pluginID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #51 

This syncs the storage on plugins with the expected structure on the verifier repo, after the removal of `plugin_type` and addition of `recipe` upstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new non-nullable "recipe" field to plugin policies, visible in policy management interfaces.
- **Bug Fixes**
	- Enhanced plugin identification and validation by switching from string-based types to unique plugin IDs in policy creation, initialization, and validation.
- **Chores**
	- Updated dependencies for improved stability and removed unused packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->