### PR TITLE
gha: add workflow to run migrations

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -1,0 +1,124 @@
+name: Migration Test
+
+on:
+  push:
+
+jobs:
+  migration-test:
+    runs-on: ubuntu-latest
+    
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: myuser
+          POSTGRES_PASSWORD: mypassword
+          POSTGRES_DB: vultisig-plugin
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      
+      redis:
+        image: redis:7
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+      
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.2'
+      
+      - name: Download go-wrappers
+        run: |
+          git clone https://github.com/vultisig/go-wrappers.git ../go-wrappers
+      
+      - name: Create test config
+        run: |
+          cat > config.json <<EOF
+          {
+            "server": {
+              "host": "localhost",
+              "port": 8080,
+              "jwt_secret": "test-secret",
+              "database": {
+                "dsn": "postgres://myuser:mypassword@localhost:5432/vultisig-plugin?sslmode=disable"
+              }
+            },
+            "redis": {
+              "host": "localhost",
+              "port": "6379"
+            },
+            "block_storage_config": {
+              "host": "http://localhost:9000",
+              "region": "us-east-1",
+              "access_key": "minioadmin",
+              "secret": "minioadmin",
+              "bucket": "vultisig-verifier"
+            },
+            "plugin": {},
+            "datadog": {
+              "host": "localhost",
+              "port": "8125"
+            }
+          }
+          EOF
+      
+      - name: Build dca binary
+        run: |
+          export LD_LIBRARY_PATH=../go-wrappers/includes/linux/:$LD_LIBRARY_PATH
+          go build -o dca cmd/dca/main.go
+      
+      - name: Run dca and check migrations
+        run: |
+          export LD_LIBRARY_PATH=../go-wrappers/includes/linux/:$LD_LIBRARY_PATH
+          export VS_CONFIG_NAME=config
+          
+          # Start dca in background
+          ./dca &
+          DCA_PID=$!
+          
+          # Give it time to run migrations
+          sleep 10
+          
+          # Check if process is still running
+          if ! kill -0 $DCA_PID 2>/dev/null; then
+            echo "DCA process failed to start"
+            exit 1
+          fi
+          
+          # Check if migrations ran successfully by verifying tables exist
+          PGPASSWORD=mypassword psql -h localhost -U myuser -d vultisig-plugin -c "\dt" | grep -E "(plugin_policy|users|pricings|plugins|categories|tags|reviews|vault_tokens)" > /dev/null
+          if [ $? -ne 0 ]; then
+            echo "Migrations did not run successfully - expected tables not found"
+            kill $DCA_PID
+            exit 1
+          fi
+          
+          echo "All migrations ran successfully!"
+          
+          # Stop dca
+          kill $DCA_PID
+      
+      - name: Check migration integrity
+        run: |
+          # Verify goose migrations table exists and has entries
+          PGPASSWORD=mypassword psql -h localhost -U myuser -d vultisig-plugin -c "SELECT COUNT(*) FROM goose_db_version;" | grep -E "[0-9]+" > /dev/null
+          if [ $? -ne 0 ]; then
+            echo "Goose migrations table not found or empty"
+            exit 1
+          fi
+          
+          echo "Migration integrity check passed!"


### PR DESCRIPTION
Mirror the workflow on verifier repo to run migrations and test their consistency.

This only runs the DCA plugin binary, since any of them should be able to run the current migrations

We can expand this as we go deeper into plugin-specific db flows.