### PR TITLE
Harmonize configs: refactor database config nesting

### DIFF
--- a/.github/workflows/migration-test.yml
+++ b/.github/workflows/migration-test.yml
@@ -52,10 +52,10 @@ jobs:
             "server": {
               "host": "localhost",
               "port": 8080,
-              "jwt_secret": "test-secret",
-              "database": {
-                "dsn": "postgres://myuser:mypassword@localhost:5432/vultisig-plugin?sslmode=disable"
-              }
+              "jwt_secret": "test-secret"
+            },
+            "database": {
+              "dsn": "postgres://myuser:mypassword@localhost:5432/vultisig-plugin?sslmode=disable"
             },
             "redis": {
               "host": "localhost",

--- a/api/server_config.go
+++ b/api/server_config.go
@@ -1,7 +1,7 @@
 package api
 
 // ServerConfig holds the configuration parameters for the server.
-// 
+//
 // Fields:
 // - Host: The hostname or IP address where the server will run.
 // - Port: The port number on which the server will listen for incoming requests.
@@ -12,7 +12,4 @@ type ServerConfig struct {
 	Host             string `mapstructure:"host" json:"host,omitempty"`
 	Port             int64  `mapstructure:"port" json:"port,omitempty"`
 	EncryptionSecret string `mapstructure:"encryption_secret" json:"encryption_secret,omitempty"`
-	Database         struct {
-		DSN string `mapstructure:"dsn" json:"dsn,omitempty"`
-	} `mapstructure:"database" json:"database,omitempty"`
 }

--- a/cmd/dca/server/config.go
+++ b/cmd/dca/server/config.go
@@ -12,7 +12,10 @@ import (
 )
 
 type DCAServerConfig struct {
-	Server         api.ServerConfig                `mapstructure:"server" json:"server"`
+	Server   api.ServerConfig `mapstructure:"server" json:"server"`
+	Database struct {
+		DSN string `mapstructure:"dsn" json:"dsn,omitempty"`
+	} `mapstructure:"database" json:"database,omitempty"`
 	BaseConfigPath string                          `mapstructure:"base_config_path" json:"base_config_path,omitempty"`
 	Redis          storage.RedisConfig             `mapstructure:"redis" json:"redis,omitempty"`
 	BlockStorage   vault_config.BlockStorageConfig `mapstructure:"block_storage" json:"block_storage,omitempty"`

--- a/cmd/dca/server/main.go
+++ b/cmd/dca/server/main.go
@@ -50,7 +50,7 @@ func main() {
 		panic(err)
 	}
 
-	db, err := postgres.NewPostgresBackend(cfg.Server.Database.DSN, nil)
+	db, err := postgres.NewPostgresBackend(cfg.Database.DSN, nil)
 	if err != nil {
 		logger.Fatalf("Failed to connect to database: %v", err)
 	}

--- a/cmd/payroll/server/config.go
+++ b/cmd/payroll/server/config.go
@@ -12,7 +12,10 @@ import (
 )
 
 type PayrollServerConfig struct {
-	Server         api.ServerConfig                `mapstructure:"server" json:"server"`
+	Server   api.ServerConfig `mapstructure:"server" json:"server"`
+	Database struct {
+		DSN string `mapstructure:"dsn" json:"dsn,omitempty"`
+	} `mapstructure:"database" json:"database,omitempty"`
 	BaseConfigPath string                          `mapstructure:"base_config_path" json:"base_config_path,omitempty"`
 	Redis          storage.RedisConfig             `mapstructure:"redis" json:"redis,omitempty"`
 	BlockStorage   vault_config.BlockStorageConfig `mapstructure:"block_storage" json:"block_storage,omitempty"`

--- a/cmd/payroll/server/main.go
+++ b/cmd/payroll/server/main.go
@@ -51,7 +51,7 @@ func main() {
 		panic(err)
 	}
 
-	db, err := postgres.NewPostgresBackend(cfg.Server.Database.DSN, nil)
+	db, err := postgres.NewPostgresBackend(cfg.Database.DSN, nil)
 	if err != nil {
 		logger.Fatalf("Failed to connect to database: %v", err)
 	}

--- a/config-plugin.yaml
+++ b/config-plugin.yaml
@@ -5,12 +5,13 @@ server:
   port: 8081
   verifier_url: "http://localhost:8081"
   base_config_path: /etc/vultisig
-  database:
-    dsn: postgres://myuser:mypassword@localhost:5432/vultisig-plugin?sslmode=disable
   vaults_file_path: /tmp/plugin/vaults
   mode: plugin
   plugin:
     type: dca
+
+database:
+  dsn: postgres://myuser:mypassword@localhost:5432/vultisig-plugin?sslmode=disable
 
 relay:
   server: https://api.vultisig.com/router

--- a/config-verifier.yaml
+++ b/config-verifier.yaml
@@ -3,12 +3,13 @@
 server:
   host: localhost
   port: 8080
-  database:
-    dsn: postgres://myuser:mypassword@localhost:5432/vultisig-verifier?sslmode=disable
   vaults_file_path: /tmp/verifier/vaults
   mode: verifier
   plugin:
     type: dca
+
+database:
+  dsn: postgres://myuser:mypassword@localhost:5432/vultisig-verifier?sslmode=disable
 
 plugin:
   plugin_configs:


### PR DESCRIPTION
Database configuration is nested within the Server data structure. This is inconsistent with the configuration in the verifier repository. The database should be a dependency that the server uses, not a server property

Tested by running dca/payroll workers + servers locally. Database migrations and start up runs fine