### PR TITLE
rework and fix eth tx calldata/fee build

### DIFF
--- a/plugin/payroll/transaction.go
+++ b/plugin/payroll/transaction.go
@@ -480,7 +480,7 @@ func (p *PayrollPlugin) evmEstimateTx(
 				Gas:                  "0x" + strconv.FormatUint(gasLimit, 16),
 				MaxPriorityFeePerGas: gcommon.Bytes2Hex(gasTipCap.Bytes()),
 				MaxFeePerGas:         gcommon.Bytes2Hex(maxFeePerGas.Bytes()),
-				Value:                "0x0",
+				Value:                gcommon.Bytes2Hex(value.Bytes()),
 				Data:                 gcommon.Bytes2Hex(data),
 			},
 			"latest",

--- a/plugin/payroll/transaction.go
+++ b/plugin/payroll/transaction.go
@@ -475,14 +475,14 @@ func (p *PayrollPlugin) evmEstimateTx(
 		"eth_createAccessList",
 		[]interface{}{
 			createAccessListArgs{
-				From:                 from.Hex(),
-				To:                   to.Hex(),
-				Gas:                  "0x" + strconv.FormatUint(gasLimit, 16),
-				MaxPriorityFeePerGas: gcommon.Bytes2Hex(gasTipCap.Bytes()),
-				MaxFeePerGas:         gcommon.Bytes2Hex(maxFeePerGas.Bytes()),
-				Value:                gcommon.Bytes2Hex(value.Bytes()),
-				Data:                 gcommon.Bytes2Hex(data),
-			},
+                From:                 from.Hex(),
+                To:                   to.Hex(),
+                Gas:                  "0x" + strconv.FormatUint(gasLimit, 16),
+                MaxPriorityFeePerGas: "0x" + gcommon.Bytes2Hex(gasTipCap.Bytes()),
+                MaxFeePerGas:         "0x" + gcommon.Bytes2Hex(maxFeePerGas.Bytes()),
+                Value:                "0x" + gcommon.Bytes2Hex(value.Bytes()),
+                Data:                 "0x" + gcommon.Bytes2Hex(data),
+            },
 			"latest",
 		},
 	)


### PR DESCRIPTION
- correctly pack/unpack unsigned tx;
- correctly append signature after it signed;
- correctly work with gas and using latest EIP-1559 tx (instead of LegacyTx) for faster landing on-chain with less fees;
- refactoring to make code extendable;

Unit tests to be done in next PRs

Ref: [#61](https://github.com/vultisig/plugin/issues/61)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Payroll transactions now use EIP-1559 dynamic fee ERC20 transfers, providing improved fee estimation and transaction reliability.
- **Refactor**
	- Transaction generation and signing flows have been streamlined for better performance and maintainability.
- **Bug Fixes**
	- Enhanced concurrency when estimating gas and nonces, reducing potential delays and errors during transaction creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->