### PR TITLE
propose/sign queue flow

### DIFF
--- a/cmd/payroll/server/main.go
+++ b/cmd/payroll/server/main.go
@@ -71,7 +71,7 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Failed to connect to database: %v", err)
 	}
-	p, err := payroll.NewPayrollPlugin(db, cfg.BaseConfigPath, txIndexerService, client)
+	p, err := payroll.NewPayrollPlugin(db, cfg.BaseConfigPath, txIndexerService, client, inspector)
 	if err != nil {
 		logger.Fatalf("failed to create payroll plugin,err: %s", err)
 	}

--- a/cmd/payroll/server/main.go
+++ b/cmd/payroll/server/main.go
@@ -71,7 +71,7 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Failed to connect to database: %v", err)
 	}
-	p, err := payroll.NewPayrollPlugin(db, cfg.BaseConfigPath, txIndexerService)
+	p, err := payroll.NewPayrollPlugin(db, cfg.BaseConfigPath, txIndexerService, client)
 	if err != nil {
 		logger.Fatalf("failed to create payroll plugin,err: %s", err)
 	}

--- a/cmd/payroll/worker/main.go
+++ b/cmd/payroll/worker/main.go
@@ -80,7 +80,7 @@ func main() {
 	if err != nil {
 		panic(fmt.Errorf("failed to create postgres backend: %w", err))
 	}
-	p, err := payroll.NewPayrollPlugin(postgressDB, cfg.BaseConfigPath, txIndexerService)
+	p, err := payroll.NewPayrollPlugin(postgressDB, cfg.BaseConfigPath, txIndexerService, client)
 	if err != nil {
 		panic(fmt.Errorf("failed to create payroll plugin: %w", err))
 	}

--- a/cmd/payroll/worker/main.go
+++ b/cmd/payroll/worker/main.go
@@ -43,6 +43,7 @@ func main() {
 
 	logger := logrus.StandardLogger()
 	client := asynq.NewClient(redisOptions)
+	inspector := asynq.NewInspector(redisOptions)
 	srv := asynq.NewServer(
 		redisOptions,
 		asynq.Config{
@@ -80,7 +81,7 @@ func main() {
 	if err != nil {
 		panic(fmt.Errorf("failed to create postgres backend: %w", err))
 	}
-	p, err := payroll.NewPayrollPlugin(postgressDB, cfg.BaseConfigPath, txIndexerService, client)
+	p, err := payroll.NewPayrollPlugin(postgressDB, cfg.BaseConfigPath, txIndexerService, client, inspector)
 	if err != nil {
 		panic(fmt.Errorf("failed to create payroll plugin: %w", err))
 	}

--- a/plugin/payroll/payroll.go
+++ b/plugin/payroll/payroll.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/hibiken/asynq"
 	"github.com/sirupsen/logrus"
+	"github.com/vultisig/plugin/storage"
 	"github.com/vultisig/verifier/plugin"
 	"github.com/vultisig/verifier/tx_indexer"
-
-	"github.com/vultisig/plugin/storage"
 )
 
 var _ plugin.Plugin = (*PayrollPlugin)(nil)
@@ -20,12 +20,14 @@ type PayrollPlugin struct {
 	logger           logrus.FieldLogger
 	config           *PluginConfig
 	txIndexerService *tx_indexer.Service
+	client           *asynq.Client
 }
 
 func NewPayrollPlugin(
 	db storage.DatabaseStorage,
 	baseConfigPath string,
 	txIndexerService *tx_indexer.Service,
+	client *asynq.Client,
 ) (*PayrollPlugin, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database storage cannot be nil")
@@ -47,6 +49,7 @@ func NewPayrollPlugin(
 		logger:           logrus.WithField("plugin", "payroll"),
 		config:           cfg,
 		txIndexerService: txIndexerService,
+		client:           client,
 	}, nil
 }
 

--- a/plugin/payroll/payroll.go
+++ b/plugin/payroll/payroll.go
@@ -21,6 +21,7 @@ type PayrollPlugin struct {
 	config           *PluginConfig
 	txIndexerService *tx_indexer.Service
 	client           *asynq.Client
+	inspector        *asynq.Inspector
 }
 
 func NewPayrollPlugin(
@@ -28,6 +29,7 @@ func NewPayrollPlugin(
 	baseConfigPath string,
 	txIndexerService *tx_indexer.Service,
 	client *asynq.Client,
+	inspector *asynq.Inspector,
 ) (*PayrollPlugin, error) {
 	if db == nil {
 		return nil, fmt.Errorf("database storage cannot be nil")
@@ -50,6 +52,7 @@ func NewPayrollPlugin(
 		config:           cfg,
 		txIndexerService: txIndexerService,
 		client:           client,
+		inspector:        inspector,
 	}, nil
 }
 

--- a/plugin/payroll/policy.go
+++ b/plugin/payroll/policy.go
@@ -98,7 +98,8 @@ func (p *PayrollPlugin) ValidateProposedTransactions(policy vtypes.PluginPolicy,
 			return fmt.Errorf("transaction destination is nil")
 		}
 
-		if strings.ToLower(txDestination.Hex()) != strings.ToLower(payrollPolicy.TokenID[i]) { // todo : why we compare to tokenId and not recipient address?
+		if strings.ToLower(txDestination.Hex()) != strings.ToLower(payrollPolicy.TokenID[i]) {
+			// ERC20 transfer tx 'to' is contract address, and 'recipient' encoded in calldata
 			return fmt.Errorf("transaction destination does not match token ID")
 		}
 

--- a/plugin/payroll/transaction.go
+++ b/plugin/payroll/transaction.go
@@ -116,7 +116,7 @@ func (p *PayrollPlugin) initSign(
 			return ctx.Err()
 		case <-time.After(3 * time.Second):
 			taskInfo, er := p.inspector.GetTaskInfo(tasks.QUEUE_NAME, task.ID)
-			if er == nil {
+			if er != nil {
 				p.logger.WithError(er).Error("p.inspector.GetTaskInfo(tasks.QUEUE_NAME, task.ID)")
 				return fmt.Errorf("p.inspector.GetTaskInfo: %w", er)
 			}


### PR DESCRIPTION
- Build & propose sign requests with unsigned tx object;
- Once signed append signature to tx and broadcast to node;

To be implemented next: https://github.com/vultisig/plugin/blob/main/plugin/payroll/transaction.go#L116-L117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved transaction signing process with asynchronous task management, including automatic polling and completion handling.
  - Transactions are now tracked before signing, providing better integration with transaction indexing.
  - Added enhanced task inspection capabilities to support background job management.

- **Bug Fixes**
  - Eliminated redundant transaction creation and unnecessary data decoding during transaction processing.

- **Refactor**
  - Streamlined transaction finalization by simplifying the signing completion process and removing unused parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->