### PR TITLE
api: remove getDerivedPublicKey

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -14,7 +14,6 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/labstack/gommon/log"
 	"github.com/sirupsen/logrus"
-	"github.com/vultisig/mobile-tss-lib/tss"
 	vcommon "github.com/vultisig/verifier/common"
 	"github.com/vultisig/verifier/plugin"
 	vtypes "github.com/vultisig/verifier/types"
@@ -103,7 +102,6 @@ func (s *Server) StartServer() error {
 	e.Validator = &vv.VultisigValidator{Validator: validator.New()}
 
 	e.GET("/ping", s.Ping)
-	e.GET("/getDerivedPublicKey", s.GetDerivedPublicKey)
 	e.POST("/signFromPlugin", s.SignPluginMessages)
 
 	grp := e.Group("/vault")
@@ -128,34 +126,6 @@ func (s *Server) StartServer() error {
 
 func (s *Server) Ping(c echo.Context) error {
 	return c.String(http.StatusOK, "Payroll & DCA Plugin server is running")
-}
-
-// GetDerivedPublicKey is a handler to get the derived public key
-func (s *Server) GetDerivedPublicKey(c echo.Context) error {
-	publicKey := c.QueryParam("publicKey")
-	if publicKey == "" {
-		return fmt.Errorf("publicKey is required")
-	}
-	hexChainCode := c.QueryParam("hexChainCode")
-	if hexChainCode == "" {
-		return fmt.Errorf("hexChainCode is required")
-	}
-	derivePath := c.QueryParam("derivePath")
-	if derivePath == "" {
-		return fmt.Errorf("derivePath is required")
-	}
-	isEdDSA := false
-	isEdDSAstr := c.QueryParam("isEdDSA")
-	if isEdDSAstr == "true" {
-		isEdDSA = true
-	}
-
-	derivedPublicKey, err := tss.GetDerivedPubKey(publicKey, hexChainCode, derivePath, isEdDSA)
-	if err != nil {
-		return fmt.Errorf("fail to get derived public key from tss, err: %w", err)
-	}
-
-	return c.JSON(http.StatusOK, derivedPublicKey)
 }
 
 // ReshareVault is a handler to reshare a vault


### PR DESCRIPTION
Fixes #106 

Remove unused code leftover from vultiserver

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * The endpoint for deriving a public key has been removed from the server API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->