### PR TITLE
Fix policy decode

### DIFF
--- a/plugin/payroll/policy.go
+++ b/plugin/payroll/policy.go
@@ -153,7 +153,7 @@ func (p *PayrollPlugin) ValidatePluginPolicy(policyDoc vtypes.PluginPolicy) erro
 	}
 	var rPolicy rtypes.Policy
 
-	policyBytes, err := base64.RawStdEncoding.DecodeString(policyDoc.Recipe)
+	policyBytes, err := base64.StdEncoding.DecodeString(policyDoc.Recipe)
 	if err != nil {
 		return fmt.Errorf("failed to decode policy recipe: %w", err)
 	}


### PR DESCRIPTION
Follow the same patter in:
https://github.com/vultisig/verifier/blob/0d7a07d1969c01f043ed699bc2137b9696b4f72a/types/policy.go#L60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy recipe decoding to handle standard base64 encoding with padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->