### PR TITLE
fix: update local party prefix in payroll worker example configuration

### DIFF
--- a/payroll.worker.example.json
+++ b/payroll.worker.example.json
@@ -3,7 +3,7 @@
     "relay": {
       "server": "https://api.vultisig.com/router"
     },
-    "local_party_prefix": "payroll-plugin-",
+    "local_party_prefix": "payroll-plugin-0000",
     "queue_email_task": false,
     "encryption_secret": "test123"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to use a new prefix value for the local party in the payroll plugin example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->