### PR TITLE
storage: don't log DSN

### DIFF
--- a/storage/postgres/db.go
+++ b/storage/postgres/db.go
@@ -22,7 +22,6 @@ type MigrationOptions struct {
 }
 
 func NewPostgresBackend(dsn string, opts *MigrationOptions) (*PostgresBackend, error) {
-	logrus.Info("Connecting to database with DSN: ", dsn)
 	pool, err := pgxpool.New(context.Background(), dsn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)


### PR DESCRIPTION
Since we stream logs to graylog now, we shouldn't log the DSN including the password and host details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed logging of the database connection string during Postgres backend initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->