### PR TITLE
🎨 Split verification types

### DIFF
--- a/api/plugin.go
+++ b/api/plugin.go
@@ -179,7 +179,7 @@ func (s *Server) CreatePluginPolicy(c echo.Context) error {
 
 	// We re-init plugin as verification server doesn't have plugin defined
 
-	if err := s.plugin.ValidatePluginPolicy(policy); err != nil {
+	if err := s.plugin.ValidateCreatePluginPolicy(policy); err != nil {
 		s.logger.WithError(err).Error("failed to validate plugin policy")
 		return c.JSON(http.StatusBadRequest, NewErrorResponse("failed to validate policy"))
 	}
@@ -209,7 +209,7 @@ func (s *Server) UpdatePluginPolicyById(c echo.Context) error {
 		return fmt.Errorf("fail to parse request, err: %w", err)
 	}
 
-	if err := s.plugin.ValidatePluginPolicy(policy); err != nil {
+	if err := s.plugin.ValidateUpdatePluginPolicy(policy); err != nil {
 		s.logger.WithError(err).
 			WithField("plugin_id", policy.PluginID).
 			WithField("policy_id", policy.ID).
@@ -257,6 +257,13 @@ func (s *Server) DeletePluginPolicyById(c echo.Context) error {
 			WithField("policy_id", policyID).
 			Error("Failed to get plugin policy")
 		return c.JSON(http.StatusInternalServerError, NewErrorResponse("failed to get policy"))
+	}
+
+	if err := s.plugin.ValidateDeletePluginPolicy(*policy); err != nil {
+		s.logger.WithError(err).
+			WithField("policy_id", policyID).
+			Error("Failed to validate plugin policy")
+		return c.JSON(http.StatusBadRequest, NewErrorResponse("failed to validate policy"))
 	}
 
 	// This is because we have different signature stored in the database.

--- a/api/server.go
+++ b/api/server.go
@@ -14,8 +14,8 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/labstack/gommon/log"
 	"github.com/sirupsen/logrus"
+	plugincommon "github.com/vultisig/plugin/plugin/common"
 	vcommon "github.com/vultisig/verifier/common"
-	"github.com/vultisig/verifier/plugin"
 	vtypes "github.com/vultisig/verifier/types"
 	"github.com/vultisig/verifier/vault"
 
@@ -37,7 +37,7 @@ type Server struct {
 	sdClient      *statsd.Client
 	scheduler     *scheduler.SchedulerService
 	policyService service.Policy
-	plugin        plugin.Plugin
+	plugin        plugincommon.Plugin
 	logger        *logrus.Logger
 	mode          string
 }
@@ -52,7 +52,7 @@ func NewServer(
 	client *asynq.Client,
 	inspector *asynq.Inspector,
 	sdClient *statsd.Client,
-	p plugin.Plugin,
+	p plugincommon.Plugin,
 ) *Server {
 	logger := logrus.WithField("service", "plugin").Logger
 	schedulerService, err := scheduler.NewSchedulerService(

--- a/plugin/common/plugin.go
+++ b/plugin/common/plugin.go
@@ -1,0 +1,22 @@
+package common
+
+import (
+	"context"
+
+	"github.com/vultisig/mobile-tss-lib/tss"
+	rtypes "github.com/vultisig/recipes/types"
+	"github.com/vultisig/verifier/types"
+)
+
+type Plugin interface {
+	GetRecipeSpecification() *rtypes.RecipeSchema
+
+	ValidatePluginPolicy(policyDoc types.PluginPolicy) error       // Used for validating a document that already exists when signing a transaction. Mostly checks on typing and constraints.
+	ValidateUpdatePluginPolicy(policyDoc types.PluginPolicy) error // Additional validations for updating a policy.
+	ValidateCreatePluginPolicy(policyDoc types.PluginPolicy) error // Additional validations for creating a policy. e.g. can't create more than one fee policy
+	ValidateDeletePluginPolicy(policyDoc types.PluginPolicy) error // Additional validations for deleting a policy. e.g. can't delete fee policy if there are fees still pending collection or other active plugins
+
+	ProposeTransactions(policy types.PluginPolicy) ([]types.PluginKeysignRequest, error)
+	ValidateProposedTransactions(policy types.PluginPolicy, txs []types.PluginKeysignRequest) error
+	SigningComplete(ctx context.Context, signature tss.KeysignResponse, signRequest types.PluginKeysignRequest, policy types.PluginPolicy) error
+}

--- a/plugin/dca/dca.go
+++ b/plugin/dca/dca.go
@@ -21,7 +21,6 @@ import (
 	"github.com/vultisig/mobile-tss-lib/tss"
 	"github.com/vultisig/verifier/address"
 	vcommon "github.com/vultisig/verifier/common"
-	"github.com/vultisig/verifier/plugin"
 	vtypes "github.com/vultisig/verifier/types"
 
 	rtypes "github.com/vultisig/recipes/types"
@@ -29,6 +28,7 @@ import (
 	"github.com/vultisig/plugin/common"
 	"github.com/vultisig/plugin/internal/sigutil"
 	"github.com/vultisig/plugin/pkg/uniswap"
+	plugincommon "github.com/vultisig/plugin/plugin/common"
 	"github.com/vultisig/plugin/storage"
 )
 
@@ -47,7 +47,7 @@ var (
 	ErrCompletedPolicy = errors.New("policy completed all swaps")
 )
 
-var _ plugin.Plugin = (*DCAPlugin)(nil)
+var _ plugincommon.Plugin = (*DCAPlugin)(nil)
 
 type DCAPlugin struct {
 	uniswapClient *uniswap.Client
@@ -229,6 +229,16 @@ func (p *DCAPlugin) ValidatePluginPolicy(policyDoc vtypes.PluginPolicy) error {
 	}
 
 	return nil
+}
+
+func (p *DCAPlugin) ValidateCreatePluginPolicy(policyDoc vtypes.PluginPolicy) error {
+	return p.ValidatePluginPolicy(policyDoc)
+}
+func (p *DCAPlugin) ValidateUpdatePluginPolicy(policyDoc vtypes.PluginPolicy) error {
+	return p.ValidatePluginPolicy(policyDoc)
+}
+func (p *DCAPlugin) ValidateDeletePluginPolicy(policyDoc vtypes.PluginPolicy) error {
+	return p.ValidatePluginPolicy(policyDoc)
 }
 
 func validateInterval(intervalStr string, frequency string) error {

--- a/plugin/fees/fees.go
+++ b/plugin/fees/fees.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/sirupsen/logrus"
 	vcommon "github.com/vultisig/verifier/common"
-	"github.com/vultisig/verifier/plugin"
 	"github.com/vultisig/verifier/tx_indexer"
 	vtypes "github.com/vultisig/verifier/types"
 	"golang.org/x/sync/errgroup"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/vultisig/plugin/internal/types"
 	"github.com/vultisig/plugin/internal/verifierapi"
+	"github.com/vultisig/plugin/plugin/common"
 	"github.com/vultisig/plugin/storage"
 	"github.com/vultisig/recipes/sdk/evm"
 )
@@ -29,7 +29,7 @@ All key logic related to fees will go here, that includes
 - getting fee information
 */
 
-var _ plugin.Plugin = (*FeePlugin)(nil)
+var _ common.Plugin = (*FeePlugin)(nil)
 
 type FeePlugin struct {
 	vaultService     *vault.ManagementService

--- a/plugin/fees/policy.go
+++ b/plugin/fees/policy.go
@@ -19,6 +19,18 @@ func (fp *FeePlugin) ValidatePluginPolicy(policyDoc vtypes.PluginPolicy) error {
 	return plugin.ValidatePluginPolicy(policyDoc, fp.GetRecipeSpecification())
 }
 
+func (fp *FeePlugin) ValidateUpdatePluginPolicy(policyDoc vtypes.PluginPolicy) error {
+	return plugin.ValidatePluginPolicy(policyDoc, fp.GetRecipeSpecification())
+}
+
+func (fp *FeePlugin) ValidateCreatePluginPolicy(policyDoc vtypes.PluginPolicy) error {
+	return plugin.ValidatePluginPolicy(policyDoc, fp.GetRecipeSpecification())
+}
+
+func (fp *FeePlugin) ValidateDeletePluginPolicy(policyDoc vtypes.PluginPolicy) error {
+	return plugin.ValidatePluginPolicy(policyDoc, fp.GetRecipeSpecification())
+}
+
 func (fp *FeePlugin) GetRecipeSpecification() *rtypes.RecipeSchema {
 	return &rtypes.RecipeSchema{
 		Version:         1, // Schema version

--- a/plugin/payroll/payroll.go
+++ b/plugin/payroll/payroll.go
@@ -6,15 +6,15 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/hibiken/asynq"
 	"github.com/sirupsen/logrus"
+	"github.com/vultisig/plugin/plugin/common"
 	"github.com/vultisig/plugin/storage"
 	"github.com/vultisig/recipes/sdk/evm"
-	"github.com/vultisig/verifier/common"
-	"github.com/vultisig/verifier/plugin"
+	vcommon "github.com/vultisig/verifier/common"
 	"github.com/vultisig/verifier/tx_indexer"
 	"github.com/vultisig/verifier/vault"
 )
 
-var _ plugin.Plugin = (*PayrollPlugin)(nil)
+var _ common.Plugin = (*PayrollPlugin)(nil)
 
 type PayrollPlugin struct {
 	db               storage.DatabaseStorage
@@ -50,7 +50,7 @@ func NewPayrollPlugin(
 		return nil, err
 	}
 
-	ethEvmChainID, err := common.Ethereum.EvmID()
+	ethEvmChainID, err := vcommon.Ethereum.EvmID()
 	if err != nil {
 		return nil, fmt.Errorf("common.Ethereum.EvmID: %w", err)
 	}

--- a/plugin/payroll/policy.go
+++ b/plugin/payroll/policy.go
@@ -52,3 +52,15 @@ func (p *PayrollPlugin) ValidateProposedTransactions(policy vtypes.PluginPolicy,
 func (p *PayrollPlugin) ValidatePluginPolicy(policyDoc vtypes.PluginPolicy) error {
 	return plugin.ValidatePluginPolicy(policyDoc, p.GetRecipeSpecification())
 }
+
+func (p *PayrollPlugin) ValidateCreatePluginPolicy(policyDoc vtypes.PluginPolicy) error {
+	return p.ValidatePluginPolicy(policyDoc)
+}
+
+func (p *PayrollPlugin) ValidateUpdatePluginPolicy(policyDoc vtypes.PluginPolicy) error {
+	return p.ValidatePluginPolicy(policyDoc)
+}
+
+func (p *PayrollPlugin) ValidateDeletePluginPolicy(policyDoc vtypes.PluginPolicy) error {
+	return p.ValidatePluginPolicy(policyDoc)
+}


### PR DESCRIPTION
There is a need to be able to verify a policy at different times in different contexts.

For instance:
- When proposing transactions
- On creation
- On deletion
- On update

Use cases are that more than one fee plugin shouldn't be installed at a time, or that the fee plugin shouldn't be deleted if there are still fees pending collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced plugin policy validation with distinct checks for creation, update, and deletion operations, improving error handling and feedback for invalid policies.

* **Refactor**
  * Updated internal plugin interfaces and implementations to support the new validation methods, ensuring consistent behavior across all plugin types.
  * Streamlined plugin integration by aligning plugin type usage throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->