### PR TITLE
✨ Resend stuck txs if nonce is the same as pending

### DIFF
--- a/etc/vultisig/fee.yml
+++ b/etc/vultisig/fee.yml
@@ -14,3 +14,4 @@ jobs:
     post:
         cronexpr: "@every 5m"
         max_concurrent_jobs: 10
+dry_run: false

--- a/internal/types/fees.go
+++ b/internal/types/fees.go
@@ -37,3 +37,12 @@ type FeeRun struct {
 	FeeCount    int         `db:"fee_count"`
 	Fees        []Fee       `db:"fees"`
 }
+
+type FeeRunTx struct {
+	ID          uuid.UUID `db:"id"`
+	FeeRunID    uuid.UUID `db:"fee_run_id"`
+	Tx          string    `db:"tx"`
+	Hash        string    `db:"hash"`
+	BlockNumber uint64    `db:"block_number"`
+	CreatedAt   time.Time `db:"created_at"`
+}

--- a/storage/db.go
+++ b/storage/db.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -22,14 +23,16 @@ type DatabaseStorage interface {
 	InsertPluginPolicyTx(ctx context.Context, dbTx pgx.Tx, policy vtypes.PluginPolicy) (*vtypes.PluginPolicy, error)
 	UpdatePluginPolicyTx(ctx context.Context, dbTx pgx.Tx, policy vtypes.PluginPolicy) (*vtypes.PluginPolicy, error)
 
-	CreateFeeRun(ctx context.Context, policyId uuid.UUID, state types.FeeRunState, fees ...verifierapi.FeeDto) (*types.FeeRun, error)
-	SetFeeRunSent(ctx context.Context, runId uuid.UUID, txHash string) error
-	SetFeeRunSuccess(ctx context.Context, runId uuid.UUID) error
+	CreateFeeRun(ctx context.Context, dbTx pgx.Tx, policyId uuid.UUID, state types.FeeRunState, fees ...verifierapi.FeeDto) (*types.FeeRun, error)
+	SetFeeRunSent(ctx context.Context, dbTx pgx.Tx, runId uuid.UUID, txHash string) error
+	SetFeeRunSuccess(ctx context.Context, dbTx pgx.Tx, runId uuid.UUID) error
 	GetAllFeeRuns(ctx context.Context, statuses ...types.FeeRunState) ([]types.FeeRun, error) // If no statuses are provided, all fee runs are returned.
 	GetFees(ctx context.Context, feeIds ...uuid.UUID) ([]types.Fee, error)
 	GetPendingFeeRun(ctx context.Context, policyId uuid.UUID) (*types.FeeRun, error)
-	CreateFee(ctx context.Context, runId uuid.UUID, fee verifierapi.FeeDto) error
+	CreateFee(ctx context.Context, dbTx pgx.Tx, runId uuid.UUID, fee verifierapi.FeeDto) error
 	GetFeeRuns(ctx context.Context, state types.FeeRunState) ([]types.FeeRun, error)
+	CreateFeeRunTx(ctx context.Context, dbTx pgx.Tx, runId uuid.UUID, tx []byte, hash string, blockNumber uint64, chainID *big.Int) error
+	GetFeeRunTxs(ctx context.Context, runId uuid.UUID) ([]types.FeeRunTx, error)
 
 	Pool() *pgxpool.Pool
 }

--- a/storage/postgres/migrations/plugin/20250630152230_fee_runs.sql
+++ b/storage/postgres/migrations/plugin/20250630152230_fee_runs.sql
@@ -38,6 +38,16 @@ CREATE INDEX IF NOT EXISTS idx_fee_run_status ON fee_run(status);
 CREATE INDEX IF NOT EXISTS idx_fee_run_created_at ON fee_run(created_at);
 CREATE INDEX IF NOT EXISTS idx_fee_id_fee_run_id ON fee(fee_run_id);
 
+CREATE TABLE IF NOT EXISTS fee_run_tx (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    fee_run_id UUID NOT NULL REFERENCES fee_run(id) ON DELETE CASCADE,
+    chain_id BIGINT NOT NULL,
+    tx TEXT NOT NULL,
+    hash VARCHAR(66) NOT NULL,
+    block_number BIGINT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW()
+);
+
 -- Create trigger to update updated_at timestamp
 CREATE OR REPLACE FUNCTION update_updated_at_column()
 RETURNS TRIGGER AS $$

--- a/storage/postgres/schema/schema.sql
+++ b/storage/postgres/schema/schema.sql
@@ -77,6 +77,16 @@ CREATE TABLE "fee_run" (
     CONSTRAINT "fee_run_status_check" CHECK ((("status")::"text" = ANY ((ARRAY['draft'::character varying, 'sent'::character varying, 'completed'::character varying, 'failed'::character varying])::"text"[])))
 );
 
+CREATE TABLE "fee_run_tx" (
+    "id" "uuid" DEFAULT "gen_random_uuid"() NOT NULL,
+    "fee_run_id" "uuid" NOT NULL,
+    "chain_id" bigint NOT NULL,
+    "tx" "text" NOT NULL,
+    "hash" character varying(66) NOT NULL,
+    "block_number" bigint NOT NULL,
+    "created_at" timestamp without time zone DEFAULT "now"()
+);
+
 CREATE VIEW "fee_run_with_totals" AS
  SELECT "fr"."id",
     "fr"."status",
@@ -133,6 +143,9 @@ ALTER TABLE ONLY "fee"
 ALTER TABLE ONLY "fee_run"
     ADD CONSTRAINT "fee_run_pkey" PRIMARY KEY ("id");
 
+ALTER TABLE ONLY "fee_run_tx"
+    ADD CONSTRAINT "fee_run_tx_pkey" PRIMARY KEY ("id");
+
 ALTER TABLE ONLY "plugin_policies"
     ADD CONSTRAINT "plugin_policies_pkey" PRIMARY KEY ("id");
 
@@ -173,4 +186,7 @@ ALTER TABLE ONLY "fee"
 
 ALTER TABLE ONLY "fee_run"
     ADD CONSTRAINT "fee_run_policy_id_fkey" FOREIGN KEY ("policy_id") REFERENCES "plugin_policies"("id") ON DELETE CASCADE;
+
+ALTER TABLE ONLY "fee_run_tx"
+    ADD CONSTRAINT "fee_run_tx_fee_run_id_fkey" FOREIGN KEY ("fee_run_id") REFERENCES "fee_run"("id") ON DELETE CASCADE;
 


### PR DESCRIPTION
This adds dry run functionality, for testing locally without the need of sending txs, if nonces match on a not found tx it automatically resends

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a dry-run mode in the fee configuration.
  * Introduced enhanced transaction rebroadcasting for pending fee transactions.
  * Added storage and retrieval of fee run transaction history.
  * Improved Ethereum transaction decoding and signing capabilities.
  * New database table for storing detailed fee run transaction data.

* **Improvements**
  * Enhanced transactional consistency for fee operations.
  * Improved error logging and database transaction handling for fee processing.

* **Bug Fixes**
  * Addressed potential state mismatches between database and external verifier during fee run status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->