### PR TITLE
⚡️ Pass specific fee ids to the sign request

### DIFF
--- a/plugin/fees/transaction.go
+++ b/plugin/fees/transaction.go
@@ -57,80 +57,97 @@ func (fp *FeePlugin) proposeTransactions(ctx context.Context, policy vtypes.Plug
 	var magicConstantRecipientValue rtypes.MagicConstant = rtypes.MagicConstant_UNSPECIFIED
 	var token string
 	// This should only return one rule, but in case there are more/fewer rules, we'll loop through them all and error if it's the case.
-	for _, rule := range recipe.Rules {
 
-		// This section of code goes through the rules in the fee policy. It looks for the recipient of the fee collection policy and extracts it. If other data is found throws an error as they're unsupported rules.
-		var recipient string // The address specified in the fee policy.
-		switch rule.Resource {
-		case "ethereum.erc20.transfer":
-			for _, constraint := range rule.ParameterConstraints {
-				if constraint.ParameterName == "recipient" {
-					if constraint.Constraint.Type != rtypes.ConstraintType_CONSTRAINT_TYPE_MAGIC_CONSTANT {
-						return nil, fmt.Errorf("recipient constraint is not a magic constant")
-					}
-					iv, err := strconv.ParseInt(constraint.Constraint.GetFixedValue(), 10, 64)
-					if err != nil {
-						return nil, fmt.Errorf("failed to parse fixed value: %v", err)
-					}
-					magicConstantRecipientValue = rtypes.MagicConstant(iv)
+	if len(recipe.Rules) != 1 {
+		return nil, fmt.Errorf("expected 1 rule, got %d", len(recipe.Rules))
+	}
+	rule := recipe.Rules[0]
+
+	var recipient string // should be a magic constant defined in the fee policy
+	switch rule.Resource {
+	case "ethereum.erc20.transfer":
+		for _, constraint := range rule.ParameterConstraints {
+			if constraint.ParameterName == "recipient" {
+				if constraint.Constraint.Type != rtypes.ConstraintType_CONSTRAINT_TYPE_MAGIC_CONSTANT {
+					return nil, fmt.Errorf("recipient constraint is not a magic constant")
 				}
+				iv, err := strconv.ParseInt(constraint.Constraint.GetFixedValue(), 10, 64)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse fixed value: %v", err)
+				}
+				magicConstantRecipientValue = rtypes.MagicConstant(iv)
 			}
-		default:
-			return nil, fmt.Errorf("unsupported rule: %v", rule.Id)
+			if constraint.ParameterName == "token" {
+				if constraint.Constraint.Type != rtypes.ConstraintType_CONSTRAINT_TYPE_FIXED {
+					return nil, fmt.Errorf("token constraint is not a fixed value")
+				}
+				token = constraint.Constraint.GetFixedValue()
+			}
 		}
+	default:
+		return nil, fmt.Errorf("unsupported rule: %v", rule.Id)
+	}
 
-		if magicConstantRecipientValue != rtypes.MagicConstant_VULTISIG_TREASURY {
-			return nil, fmt.Errorf("recipient constraint is not a treasury magic constant")
-		}
-		treasuryResolver := resolver.NewDefaultTreasuryResolver()
-		recipient, _, err := treasuryResolver.Resolve(magicConstantRecipientValue, "ethereum", "usdc")
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve treasury address: %v", err)
-		}
+	if magicConstantRecipientValue != rtypes.MagicConstant_VULTISIG_TREASURY {
+		return nil, fmt.Errorf("recipient constraint is not a treasury magic constant")
+	}
+	treasuryResolver := resolver.NewDefaultTreasuryResolver()
+	recipient, _, err = treasuryResolver.Resolve(magicConstantRecipientValue, "ethereum", "usdc")
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve treasury address: %v", err)
+	}
 
-		if gcommon.HexToAddress(token) != gcommon.HexToAddress(usdc.Address) {
-			return nil, fmt.Errorf("token address does not match usdc address")
-		}
-		amount := run.TotalAmount
-		tx, err := fp.eth.MakeAnyTransfer(ctx,
-			gcommon.HexToAddress(fromAddress),
-			gcommon.HexToAddress(recipient),
-			gcommon.HexToAddress(usdc.Address),
-			big.NewInt(int64(amount)))
+	if gcommon.HexToAddress(token) != gcommon.HexToAddress(usdc.Address) {
+		return nil, fmt.Errorf("token address does not match usdc address")
+	}
+	amount := run.TotalAmount
+	tx, err := fp.eth.MakeAnyTransfer(ctx,
+		gcommon.HexToAddress(fromAddress),
+		gcommon.HexToAddress(recipient),
+		gcommon.HexToAddress(usdc.Address),
+		big.NewInt(int64(amount)))
 
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate unsigned transaction: %w", err)
-		}
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate unsigned transaction: %w", err)
+	}
 
-		txHex := hexutil.Encode(tx)
-		txData, e := reth.DecodeUnsignedPayload(tx)
-		if e != nil {
-			return nil, fmt.Errorf("ethereum.DecodeUnsignedPayload: %w", e)
-		}
+	txHex := hexutil.Encode(tx)
+	txData, e := reth.DecodeUnsignedPayload(tx)
+	if e != nil {
+		return nil, fmt.Errorf("ethereum.DecodeUnsignedPayload: %w", e)
+	}
 
-		txHashToSign := etypes.LatestSignerForChainID(fp.config.ChainId).Hash(etypes.NewTx(txData))
-		msgHash := sha256.Sum256(txHashToSign.Bytes())
-		signRequest := vtypes.PluginKeysignRequest{
-			KeysignRequest: vtypes.KeysignRequest{
-				PublicKey: policy.PublicKey,
-				Messages: []vtypes.KeysignMessage{
-					{
-						Message:      base64.StdEncoding.EncodeToString(txHashToSign.Bytes()),
-						RawMessage:   txHex,
-						Chain:        vcommon.Ethereum,
-						Hash:         base64.StdEncoding.EncodeToString(msgHash[:]),
-						HashFunction: vtypes.HashFunction_SHA256,
+	feeIds := []uuid.UUID{}
+	for _, fee := range run.Fees {
+		feeIds = append(feeIds, fee.ID)
+	}
+
+	txHashToSign := etypes.LatestSignerForChainID(fp.config.ChainId).Hash(etypes.NewTx(txData))
+	msgHash := sha256.Sum256(txHashToSign.Bytes())
+	signRequest := vtypes.PluginKeysignRequest{
+		KeysignRequest: vtypes.KeysignRequest{
+			PublicKey: policy.PublicKey,
+			Messages: []vtypes.KeysignMessage{
+				{
+					Message:      base64.StdEncoding.EncodeToString(txHashToSign.Bytes()),
+					RawMessage:   txHex,
+					Chain:        vcommon.Ethereum,
+					Hash:         base64.StdEncoding.EncodeToString(msgHash[:]),
+					HashFunction: vtypes.HashFunction_SHA256,
+					CustomFields: map[string]interface{}{
+						"fee_ids": feeIds,
 					},
 				},
-				SessionID:        "",
-				HexEncryptionKey: "",
-				PolicyID:         policy.ID,
-				PluginID:         policy.PluginID.String(),
 			},
-			Transaction: txHex,
-		}
-		txs = append(txs, signRequest)
+			SessionID:        "",
+			HexEncryptionKey: "",
+			PolicyID:         policy.ID,
+			PluginID:         policy.PluginID.String(),
+		},
+		Transaction: txHex,
 	}
+	txs = append(txs, signRequest)
+
 	return txs, nil
 }
 


### PR DESCRIPTION
This passes specific fee ids to the verifier rather than the verifier simply wanting to reclear all fees

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified fee rule processing by enforcing a single rule and adding explicit error handling for rule validation.

* **New Features**
  * Keysign requests now include a new field displaying associated fee IDs for improved tracking.

* **Bug Fixes**
  * Improved validation of recipient and token addresses to prevent incorrect transaction creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->